### PR TITLE
Add xRegistry links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # MarkMyWord
+[![Registry](https://img.shields.io/badge/Registry-SpecWorks-blue)](https://spec-works.github.io/registry/parts/markmyword/)
+
 
 Software component for bidirectional conversion between CommonMark/GitHub Flavored Markdown and Microsoft Word (.docx) documents.
 

--- a/specs.json
+++ b/specs.json
@@ -29,6 +29,11 @@
       "type": "text/html",
       "rel": "related",
       "title": "Open XML SDK Documentation"
+    },
+    {
+      "rel": "registry",
+      "title": "Part registry entry",
+      "href": "https://spec-works.github.io/registry/parts/markmyword/"
     }
   ]
 }


### PR DESCRIPTION
Adds xRegistry links for specification-centric component discovery.

## Changes

- **specs.json**: Added registry link (rel: registry)
- **README.md**: Added registry badge

## Registry Entry

This part is now discoverable in the SpecWorks registry.

## Related

- spec-works/specification#6 (Deploy xRegistry using GitHub Pages)
- Phase 5: Integration with parts