### PR TITLE
Release v0.9.0

### DIFF
--- a/dotnet/RELEASE_NOTES.md
+++ b/dotnet/RELEASE_NOTES.md
@@ -1,5 +1,38 @@
 # Release Notes
 
+## Version 0.9.0
+
+### Bug Fixes
+
+#### Word Online Table Rendering Compatibility
+- Fixed table rendering to produce Word Online-compatible output
+- Tables now use explicit `TableCellWidth` with `Dxa` units for consistent column sizing
+- Added `TableBorders` with proper border definitions for reliable rendering across Word desktop and Word Online
+- Improved `GridColumn` width calculations for uniform table layout
+
+#### Unicode and Emoji Handling
+- Added `TextSanitizer` utility for safe OpenXML text serialization
+- Preserves valid surrogate pairs (emoji, astral plane Unicode characters U+10000+)
+- Strips only XML-invalid control characters and orphaned surrogates
+- Sanitizes URL fallback text and image alt text in `LinkInlineRenderer`
+- Applied sanitization across all inline and block renderers: `CodeBlockRenderer`, `CodeInlineRenderer`, `EmphasisInlineRenderer`, `LiteralInlineRenderer`, and `TableRenderer`
+
+### New Components
+
+- `OpenXml/TextSanitizer.cs` — Static utility for sanitizing text before OpenXML insertion
+
+### Testing
+
+- Added `TableWebCompatibilityTests` — 460 lines of tests covering Word Online table rendering
+- Added `UnicodeHandlingTests` — 423 lines of tests covering emoji, surrogate pair, and control character handling
+- Cleaned up unused parameters in `PipelineParityTests`
+
+### Breaking Changes
+
+None
+
+---
+
 ## Version 0.6.0
 
 ### Breaking Changes


### PR DESCRIPTION
## Release v0.9.0

### Summary
Prepares the v0.9.0 release with updated release notes. Version was already bumped in #40.

### Changes since v0.8.0
- **Word Online table rendering** - Fixed table rendering to produce Word Online-compatible output with explicit cell widths, borders, and grid columns (PR #39)
- **Unicode/emoji handling** - Added TextSanitizer utility that preserves valid surrogate pairs while stripping XML-invalid characters. Applied across all renderers (PR #37)
- **883 lines of new tests** - TableWebCompatibilityTests (460 lines) and UnicodeHandlingTests (423 lines)

### Release Checklist
- [x] Version bumped to 0.9.0 in both csproj files (#40)
- [x] Release notes updated (this PR)
- [ ] Merge this PR
- [ ] Push tag v0.9.0 to trigger CI pipeline

### Post-Merge
After merging, push the tag to trigger the full release pipeline:

    git checkout main && git pull
    git tag v0.9.0
    git push origin v0.9.0

This triggers the build-and-publish.yml workflow which publishes:
- SpecWorks.MarkMyWord.0.9.0.nupkg
- SpecWorks.MarkMyWord.0.9.0.snupkg
- SpecWorks.MarkMyWord.CLI.0.9.0.nupkg