### PR TITLE
Fix emoji rendering in Mermaid diagrams and Word output

### DIFF
--- a/dotnet/src/MarkMyWord/Converters/BlockRenderers/TableRenderer.cs
+++ b/dotnet/src/MarkMyWord/Converters/BlockRenderers/TableRenderer.cs
@@ -268,8 +268,60 @@ public class TableRenderer : OpenXmlObjectRenderer<MarkdigTable>
                 run.AppendChild(new Break());
                 paragraph.AppendChild(run);
             }
-            // For any other inline types, just skip them for now
-            // (LinkInline would need special handling if needed in tables)
+            else if (inline is Markdig.Syntax.Inlines.LinkInline link)
+            {
+                if (link.IsImage)
+                {
+                    // Skip images in tables — just show alt text
+                    var altText = link.Title ?? link.Url ?? "image";
+                    var imgRun = new Run(
+                        new RunProperties(isBold ? new Bold() : null!, new Italic()),
+                        new Text($"[Image: {TextSanitizer.Sanitize(altText)}]") { Space = SpaceProcessingModeValues.Preserve }
+                    );
+                    paragraph.AppendChild(imgRun);
+                }
+                else if (!string.IsNullOrEmpty(link.Url))
+                {
+                    var relationshipId = renderer.DocumentBuilder.AddHyperlinkRelationship(link.Url);
+
+                    var hyperlink = new Hyperlink
+                    {
+                        Id = relationshipId,
+                        History = OnOffValue.FromBoolean(true)
+                    };
+
+                    var linkProps = new RunProperties(
+                        new Color { Val = "0563C1" },
+                        new Underline { Val = UnderlineValues.Single }
+                    );
+
+                    if (isBold)
+                        linkProps.AppendChild(new Bold());
+
+                    // Extract link text from children
+                    string linkText = "";
+                    if (link.FirstChild != null)
+                    {
+                        var child = link.FirstChild;
+                        while (child != null)
+                        {
+                            if (child is Markdig.Syntax.Inlines.LiteralInline linkLiteral)
+                                linkText += linkLiteral.Content.ToString();
+                            child = child.NextSibling;
+                        }
+                    }
+
+                    if (string.IsNullOrEmpty(linkText))
+                        linkText = link.Url;
+
+                    EmojiRunHelper.AppendText(
+                        hyperlink,
+                        TextSanitizer.Sanitize(linkText),
+                        linkProps);
+
+                    paragraph.AppendChild(hyperlink);
+                }
+            }
 
             inline = inline.NextSibling;
         }

--- a/dotnet/src/MarkMyWord/Converters/BlockRenderers/TableRenderer.cs
+++ b/dotnet/src/MarkMyWord/Converters/BlockRenderers/TableRenderer.cs
@@ -204,25 +204,15 @@ public class TableRenderer : OpenXmlObjectRenderer<MarkdigTable>
         {
             if (inline is Markdig.Syntax.Inlines.LiteralInline literal)
             {
-                var run = new Run();
-                var runProps = new RunProperties();
+                var runProps = isBold ? new RunProperties(new Bold()) : null;
 
-                if (isBold)
-                {
-                    runProps.AppendChild(new Bold());
-                }
-
-                if (runProps.HasChildren)
-                {
-                    run.RunProperties = runProps;
-                }
-
-                run.AppendChild(new Text(TextSanitizer.Sanitize(literal.Content.ToString())) { Space = SpaceProcessingModeValues.Preserve });
-                paragraph.AppendChild(run);
+                EmojiRunHelper.AppendText(
+                    paragraph,
+                    TextSanitizer.Sanitize(literal.Content.ToString()),
+                    runProps);
             }
             else if (inline is Markdig.Syntax.Inlines.EmphasisInline emphasis)
             {
-                var run = new Run();
                 var runProps = new RunProperties();
 
                 if (isBold)
@@ -240,11 +230,6 @@ public class TableRenderer : OpenXmlObjectRenderer<MarkdigTable>
                     runProps.AppendChild(new Italic());
                 }
 
-                if (runProps.HasChildren)
-                {
-                    run.RunProperties = runProps;
-                }
-
                 // Recursively render emphasis content
                 if (emphasis.FirstChild != null)
                 {
@@ -253,13 +238,14 @@ public class TableRenderer : OpenXmlObjectRenderer<MarkdigTable>
                     {
                         if (emphInline is Markdig.Syntax.Inlines.LiteralInline emphLiteral)
                         {
-                            run.AppendChild(new Text(TextSanitizer.Sanitize(emphLiteral.Content.ToString())) { Space = SpaceProcessingModeValues.Preserve });
+                            EmojiRunHelper.AppendText(
+                                paragraph,
+                                TextSanitizer.Sanitize(emphLiteral.Content.ToString()),
+                                runProps.HasChildren ? runProps : null);
                         }
                         emphInline = emphInline.NextSibling;
                     }
                 }
-
-                paragraph.AppendChild(run);
             }
             else if (inline is Markdig.Syntax.Inlines.CodeInline code)
             {

--- a/dotnet/src/MarkMyWord/Converters/InlineRenderers/EmphasisInlineRenderer.cs
+++ b/dotnet/src/MarkMyWord/Converters/InlineRenderers/EmphasisInlineRenderer.cs
@@ -26,9 +26,11 @@ public class EmphasisInlineRenderer : OpenXmlObjectRenderer<EmphasisInline>
         {
             if (child is LiteralInline literal)
             {
-                var run = new Run(CreateEmphasisRunProperties(obj));
-                run.AppendChild(new Text(TextSanitizer.Sanitize(literal.Content.ToString())) { Space = SpaceProcessingModeValues.Preserve });
-                currentParagraph.AppendChild(run);
+                var emphasisProps = CreateEmphasisRunProperties(obj);
+                EmojiRunHelper.AppendText(
+                    currentParagraph,
+                    TextSanitizer.Sanitize(literal.Content.ToString()),
+                    emphasisProps);
             }
             else if (child is CodeInline codeInline)
             {

--- a/dotnet/src/MarkMyWord/Converters/InlineRenderers/LinkInlineRenderer.cs
+++ b/dotnet/src/MarkMyWord/Converters/InlineRenderers/LinkInlineRenderer.cs
@@ -68,14 +68,14 @@ public class LinkInlineRenderer : OpenXmlObjectRenderer<LinkInline>
             {
                 if (child is LiteralInline literal)
                 {
-                    var run = new WP.Run(
-                        new WP.RunProperties(
-                            new WP.Color { Val = "0563C1" },
-                            new WP.Underline { Val = WP.UnderlineValues.Single }
-                        ),
-                        new WP.Text(TextSanitizer.Sanitize(literal.Content.ToString())) { Space = SpaceProcessingModeValues.Preserve }
+                    var linkProps = new WP.RunProperties(
+                        new WP.Color { Val = "0563C1" },
+                        new WP.Underline { Val = WP.UnderlineValues.Single }
                     );
-                    hyperlink.AppendChild(run);
+                    EmojiRunHelper.AppendText(
+                        hyperlink,
+                        TextSanitizer.Sanitize(literal.Content.ToString()),
+                        linkProps);
                 }
                 child = child.NextSibling;
             }

--- a/dotnet/src/MarkMyWord/Converters/InlineRenderers/LiteralInlineRenderer.cs
+++ b/dotnet/src/MarkMyWord/Converters/InlineRenderers/LiteralInlineRenderer.cs
@@ -28,9 +28,7 @@ public class LiteralInlineRenderer : OpenXmlObjectRenderer<LiteralInline>
             currentParagraph = renderer.DocumentBuilder.AddParagraph();
         }
 
-        // Create a run with the text
-        var run = new Run();
-        run.AppendChild(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
-        currentParagraph.AppendChild(run);
+        // Use EmojiRunHelper to split emoji into separate runs with the emoji font
+        EmojiRunHelper.AppendText(currentParagraph, text);
     }
 }

--- a/dotnet/src/MarkMyWord/Diagrams/MermaidRenderer.cs
+++ b/dotnet/src/MarkMyWord/Diagrams/MermaidRenderer.cs
@@ -1,6 +1,8 @@
 using MarkMyWord.Configuration;
+using MarkMyWord.OpenXml;
 using MermaidSharp;
 using System.Globalization;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace MarkMyWord.Diagrams;
@@ -101,12 +103,25 @@ public partial class MermaidRenderer
 
         try
         {
-            var svg = Mermaid.Render(mermaidCode, RenderOptions.Default);
+            // Strip emoji characters before parsing — MermaidSharp's parser
+            // cannot handle astral-plane Unicode. We replace each unique emoji
+            // grapheme cluster with a single Private Use Area character and
+            // restore them in the SVG output after rendering.
+            var (sanitizedCode, emojiMap) = StripEmojisFromMermaid(mermaidCode);
+
+            var svg = Mermaid.Render(sanitizedCode, RenderOptions.Default);
             svg = ReplaceForeignObjectsWithText(svg);
             svg = NormalizeErDiagram(svg);
             svg = NormalizeClassDiagram(svg);
             svg = ApplyModernTheme(svg);
             svg = EnsureOpaqueBackground(svg);
+
+            // Restore emoji characters in the SVG text content
+            if (emojiMap.Count > 0)
+            {
+                svg = RestoreEmojisInSvg(svg, emojiMap);
+            }
+
             return svg;
         }
         catch (Exception ex)
@@ -374,6 +389,63 @@ public partial class MermaidRenderer
 
     private static string F(double value) =>
         value.ToString("F2", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Replaces emoji grapheme clusters in Mermaid source code with single Private Use Area
+    /// characters so MermaidSharp can parse the diagram without failing on astral-plane Unicode.
+    /// Returns the sanitized code and a mapping from PUA placeholder → original emoji.
+    /// </summary>
+    private static (string sanitized, Dictionary<string, string> emojiMap) StripEmojisFromMermaid(string mermaidCode)
+    {
+        if (!EmojiSegmenter.ContainsEmoji(mermaidCode))
+            return (mermaidCode, new Dictionary<string, string>());
+
+        var emojiToPlaceholder = new Dictionary<string, string>();
+        var placeholderToEmoji = new Dictionary<string, string>();
+        char nextPua = '\uE000';
+
+        var result = new StringBuilder(mermaidCode.Length);
+        var enumerator = System.Globalization.StringInfo.GetTextElementEnumerator(mermaidCode);
+
+        while (enumerator.MoveNext())
+        {
+            string element = enumerator.GetTextElement();
+
+            if (EmojiSegmenter.ContainsEmoji(element))
+            {
+                if (!emojiToPlaceholder.TryGetValue(element, out string? placeholder))
+                {
+                    placeholder = nextPua.ToString();
+                    emojiToPlaceholder[element] = placeholder;
+                    placeholderToEmoji[placeholder] = element;
+                    nextPua++;
+                }
+
+                result.Append(placeholder);
+            }
+            else
+            {
+                result.Append(element);
+            }
+        }
+
+        return (result.ToString(), placeholderToEmoji);
+    }
+
+    /// <summary>
+    /// Restores emoji characters in SVG output by replacing PUA placeholders.
+    /// PUA characters (U+E000+) don't appear in SVG syntax, CSS, or attribute names,
+    /// so global replacement is safe and only affects text content.
+    /// </summary>
+    private static string RestoreEmojisInSvg(string svg, Dictionary<string, string> emojiMap)
+    {
+        foreach (var (placeholder, emoji) in emojiMap)
+        {
+            svg = svg.Replace(placeholder, emoji);
+        }
+
+        return svg;
+    }
 
     [GeneratedRegex(
         @"<foreignObject\s+x=""(?<x>[0-9.]+)""\s+y=""(?<y>[0-9.]+)""\s+width=""(?<w>[0-9.]+)""\s+height=""(?<h>[0-9.]+)""[^>]*>(?<inner>.*?)</foreignObject>",

--- a/dotnet/src/MarkMyWord/Diagrams/MermaidRenderer.cs
+++ b/dotnet/src/MarkMyWord/Diagrams/MermaidRenderer.cs
@@ -363,6 +363,18 @@ public partial class MermaidRenderer
             string text = textMatch.Success ? textMatch.Groups[1].Value.Trim() : "";
             if (string.IsNullOrEmpty(text)) return match.Value;
 
+            // Decode HTML entities from the foreignObject content (e.g. &quot; → ")
+            // before re-escaping for SVG — prevents double-escaping like &amp;quot;
+            text = System.Net.WebUtility.HtmlDecode(text);
+
+            // Strip surrounding quotes that are Mermaid label syntax, not content.
+            // In Mermaid, A["Label"] means the label is "Label" — the quotes delimit
+            // the label text and should not appear in the rendered output.
+            if (text.Length >= 2 && text[0] == '"' && text[^1] == '"')
+            {
+                text = text[1..^1];
+            }
+
             double cx = x + w / 2;
             double cy = y + h / 2;
             string fontSize = h > 30 ? "13" : "11";

--- a/dotnet/src/MarkMyWord/OpenXml/DocumentBuilder.cs
+++ b/dotnet/src/MarkMyWord/OpenXml/DocumentBuilder.cs
@@ -35,6 +35,43 @@ public class DocumentBuilder : IDisposable
         MainDocumentPart = WordDocument.AddMainDocumentPart();
         MainDocumentPart.Document = new Document();
         Body = MainDocumentPart.Document.AppendChild(new Body());
+
+        CreateFontTable();
+    }
+
+    /// <summary>
+    /// Creates a font table part declaring fonts used in the document.
+    /// Notably declares "Segoe UI Emoji" so Word can properly resolve it
+    /// for supplementary-plane emoji characters (color rendering).
+    /// </summary>
+    private void CreateFontTable()
+    {
+        var fontTablePart = MainDocumentPart.AddNewPart<FontTablePart>();
+
+        var fonts = new Fonts();
+
+        fonts.AppendChild(new Font(
+            new FontCharSet { Val = "00" },
+            new FontFamily { Val = FontFamilyValues.Swiss },
+            new Pitch { Val = FontPitchValues.Variable }
+        )
+        { Name = "Calibri" });
+
+        fonts.AppendChild(new Font(
+            new FontCharSet { Val = "00" },
+            new FontFamily { Val = FontFamilyValues.Modern },
+            new Pitch { Val = FontPitchValues.Fixed }
+        )
+        { Name = "Consolas" });
+
+        fonts.AppendChild(new Font(
+            new FontCharSet { Val = "00" },
+            new FontFamily { Val = FontFamilyValues.Auto },
+            new Pitch { Val = FontPitchValues.Variable }
+        )
+        { Name = EmojiSegmenter.EmojiFontName });
+
+        fontTablePart.Fonts = fonts;
     }
 
     /// <summary>

--- a/dotnet/src/MarkMyWord/OpenXml/EmojiRunHelper.cs
+++ b/dotnet/src/MarkMyWord/OpenXml/EmojiRunHelper.cs
@@ -67,6 +67,7 @@ public static class EmojiRunHelper
             existingFonts.HighAnsi = EmojiSegmenter.EmojiFontName;
             existingFonts.ComplexScript = EmojiSegmenter.EmojiFontName;
             existingFonts.EastAsia = EmojiSegmenter.EmojiFontName;
+            existingFonts.Hint = FontTypeHintValues.EastAsia;
         }
         else
         {
@@ -76,6 +77,7 @@ public static class EmojiRunHelper
                 HighAnsi = EmojiSegmenter.EmojiFontName,
                 ComplexScript = EmojiSegmenter.EmojiFontName,
                 EastAsia = EmojiSegmenter.EmojiFontName,
+                Hint = FontTypeHintValues.EastAsia,
             });
         }
     }

--- a/dotnet/src/MarkMyWord/OpenXml/EmojiRunHelper.cs
+++ b/dotnet/src/MarkMyWord/OpenXml/EmojiRunHelper.cs
@@ -1,0 +1,82 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace MarkMyWord.OpenXml;
+
+/// <summary>
+/// Helper for creating Word runs that apply the correct font for emoji characters.
+/// Splits text into emoji and non-emoji segments, applying "Segoe UI Emoji" to
+/// emoji runs so that Word renders them in full color instead of monochrome outlines.
+/// </summary>
+public static class EmojiRunHelper
+{
+    /// <summary>
+    /// Appends one or more runs to the parent element, splitting text into emoji and
+    /// non-emoji segments. Emoji segments get the emoji font applied.
+    /// Works with Paragraph, Hyperlink, or any OpenXmlCompositeElement that accepts Run children.
+    /// </summary>
+    /// <param name="parent">Target element to append runs to (Paragraph, Hyperlink, etc.).</param>
+    /// <param name="text">The text content to append.</param>
+    /// <param name="baseRunProperties">
+    /// Optional base run properties (bold, italic, color, etc.) to clone for each run.
+    /// Pass null for unstyled runs.
+    /// </param>
+    public static void AppendText(OpenXmlCompositeElement parent, string text, RunProperties? baseRunProperties = null)
+    {
+        if (string.IsNullOrEmpty(text))
+            return;
+
+        var segments = EmojiSegmenter.Segment(text);
+
+        foreach (var segment in segments)
+        {
+            if (string.IsNullOrEmpty(segment.Text))
+                continue;
+
+            var run = new Run();
+
+            if (segment.IsEmoji)
+            {
+                var props = baseRunProperties != null
+                    ? (RunProperties)baseRunProperties.CloneNode(true)
+                    : new RunProperties();
+                ApplyEmojiFont(props);
+                run.RunProperties = props;
+            }
+            else if (baseRunProperties != null)
+            {
+                run.RunProperties = (RunProperties)baseRunProperties.CloneNode(true);
+            }
+
+            run.AppendChild(new Text(segment.Text) { Space = SpaceProcessingModeValues.Preserve });
+            parent.AppendChild(run);
+        }
+    }
+
+    /// <summary>
+    /// Sets all font slots on the run properties to the emoji font.
+    /// Covers Ascii, HighAnsi, ComplexScript, and EastAsia to ensure
+    /// consistent emoji rendering regardless of text direction or script.
+    /// </summary>
+    private static void ApplyEmojiFont(RunProperties props)
+    {
+        var existingFonts = props.GetFirstChild<RunFonts>();
+        if (existingFonts != null)
+        {
+            existingFonts.Ascii = EmojiSegmenter.EmojiFontName;
+            existingFonts.HighAnsi = EmojiSegmenter.EmojiFontName;
+            existingFonts.ComplexScript = EmojiSegmenter.EmojiFontName;
+            existingFonts.EastAsia = EmojiSegmenter.EmojiFontName;
+        }
+        else
+        {
+            props.PrependChild(new RunFonts
+            {
+                Ascii = EmojiSegmenter.EmojiFontName,
+                HighAnsi = EmojiSegmenter.EmojiFontName,
+                ComplexScript = EmojiSegmenter.EmojiFontName,
+                EastAsia = EmojiSegmenter.EmojiFontName,
+            });
+        }
+    }
+}

--- a/dotnet/src/MarkMyWord/OpenXml/EmojiSegmenter.cs
+++ b/dotnet/src/MarkMyWord/OpenXml/EmojiSegmenter.cs
@@ -1,0 +1,141 @@
+using System.Globalization;
+using System.Text;
+
+namespace MarkMyWord.OpenXml;
+
+/// <summary>
+/// Segments text into emoji and non-emoji runs for proper font handling in Word.
+/// Uses grapheme-cluster-aware segmentation to correctly handle composite emoji
+/// (ZWJ sequences, flags, skin tones, variation selectors).
+/// </summary>
+public static class EmojiSegmenter
+{
+    /// <summary>
+    /// Font name used for emoji rendering in Word documents.
+    /// Segoe UI Emoji provides full-color emoji on Windows.
+    /// </summary>
+    public const string EmojiFontName = "Segoe UI Emoji";
+
+    /// <summary>
+    /// Segments a string into contiguous runs of emoji and non-emoji text.
+    /// Adjacent segments of the same type are merged for efficiency.
+    /// </summary>
+    public static IReadOnlyList<TextSegment> Segment(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return [new TextSegment(text ?? string.Empty, false)];
+
+        // Fast path: no emoji at all
+        if (!ContainsEmoji(text))
+            return [new TextSegment(text, false)];
+
+        var segments = new List<TextSegment>();
+        var current = new StringBuilder();
+        bool currentIsEmoji = false;
+        bool firstSegment = true;
+
+        var enumerator = StringInfo.GetTextElementEnumerator(text);
+        while (enumerator.MoveNext())
+        {
+            string element = enumerator.GetTextElement();
+            bool isEmoji = IsEmojiGraphemeCluster(element);
+
+            if (firstSegment)
+            {
+                currentIsEmoji = isEmoji;
+                firstSegment = false;
+            }
+
+            if (isEmoji == currentIsEmoji)
+            {
+                current.Append(element);
+            }
+            else
+            {
+                if (current.Length > 0)
+                    segments.Add(new TextSegment(current.ToString(), currentIsEmoji));
+
+                current.Clear();
+                current.Append(element);
+                currentIsEmoji = isEmoji;
+            }
+        }
+
+        if (current.Length > 0)
+            segments.Add(new TextSegment(current.ToString(), currentIsEmoji));
+
+        return segments;
+    }
+
+    /// <summary>
+    /// Checks whether the text contains any emoji characters.
+    /// </summary>
+    public static bool ContainsEmoji(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return false;
+
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (IsEmojiCodePoint(rune.Value))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a grapheme cluster represents an emoji.
+    /// A cluster is emoji if any of its constituent code points is an emoji code point.
+    /// </summary>
+    private static bool IsEmojiGraphemeCluster(string cluster)
+    {
+        foreach (var rune in cluster.EnumerateRunes())
+        {
+            if (IsEmojiCodePoint(rune.Value))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a Unicode code point is an emoji or emoji-related character.
+    /// Covers supplementary plane emoji, variation selectors, ZWJ,
+    /// regional indicators, and common BMP emoji.
+    /// </summary>
+    private static bool IsEmojiCodePoint(int cp) =>
+        // Supplementary Multilingual Plane emoji blocks
+        (cp >= 0x1F000 && cp <= 0x1FAFF) ||
+        // Supplementary symbols and pictographs (extended)
+        (cp >= 0x1FC00 && cp <= 0x1FFFF) ||
+        // Regional indicator symbols (flags)
+        (cp >= 0x1F1E0 && cp <= 0x1F1FF) ||
+        // Variation Selector 16 (requests emoji presentation)
+        cp == 0xFE0F ||
+        // Zero-width joiner (compound emoji like 👩‍💻)
+        cp == 0x200D ||
+        // Miscellaneous Symbols (sun, cloud, stars, etc.)
+        (cp >= 0x2600 && cp <= 0x26FF) ||
+        // Dingbats (scissors, pencil, checkmarks, arrows, etc.)
+        (cp >= 0x2700 && cp <= 0x27BF) ||
+        // Miscellaneous Technical (hourglass, player controls, etc.)
+        (cp >= 0x2300 && cp <= 0x23FF) ||
+        // Geometric Shapes (squares, circles, triangles)
+        (cp >= 0x25A0 && cp <= 0x25FF) ||
+        // Misc Symbols and Arrows
+        (cp >= 0x2B05 && cp <= 0x2B55) ||
+        // Curved arrows
+        cp == 0x2934 || cp == 0x2935 ||
+        // Copyright and registered
+        cp == 0x00A9 || cp == 0x00AE ||
+        // Trademark
+        cp == 0x2122 ||
+        // Double exclamation, exclamation question
+        cp == 0x203C || cp == 0x2049;
+}
+
+/// <summary>
+/// Represents a contiguous segment of text that is either all-emoji or all-non-emoji.
+/// </summary>
+public readonly record struct TextSegment(string Text, bool IsEmoji);

--- a/dotnet/tests/MarkMyWord.Tests/Diagrams/MermaidTests.cs
+++ b/dotnet/tests/MarkMyWord.Tests/Diagrams/MermaidTests.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using FluentAssertions;
 using MarkMyWord.Configuration;
 
 namespace MarkMyWord.Tests.Diagrams;
@@ -479,5 +480,57 @@ flowchart TD
         // Should contain the raw source (not an error message from Mermaid rendering)
         Assert.Contains("flowchart", allText);
         Assert.DoesNotContain("Error", allText);
+    }
+
+    [Fact]
+    public void MermaidWithEmoji_RendersAsDiagramNotFallback()
+    {
+        // Arrange — emoji in node labels should not cause Mermaid parsing to fail
+        string markdown = @"```mermaid
+flowchart LR
+    A[""🔍 Discover""] --> B[""🤔 Understand""] --> C[""🛠️ Build""]
+```
+";
+
+        var options = new ConversionOptions
+        {
+            EnableMermaidDiagrams = true
+        };
+
+        // Act
+        using var stream = new MemoryStream();
+        MarkdownConverter.ConvertToDocx(markdown, stream, options);
+
+        // Assert — should produce a valid document without the error fallback
+        stream.Position = 0;
+        using var doc = WordprocessingDocument.Open(stream, false);
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var allText = body.InnerText;
+
+        // If emoji stripping works, it should render as a diagram (no error message)
+        Assert.DoesNotContain("Error rendering Mermaid", allText);
+    }
+
+    [Fact]
+    public void MermaidWithEmoji_ShouldNotThrow()
+    {
+        string markdown = @"```mermaid
+flowchart LR
+    A[""🔍 Discover""] --> B[""🤔 Understand""] --> C[""🛠️ Build""] --> D[""📦 Publish""] --> E[""📊 Observe""]
+```
+";
+
+        var options = new ConversionOptions
+        {
+            EnableMermaidDiagrams = true
+        };
+
+        var act = () =>
+        {
+            using var stream = new MemoryStream();
+            MarkdownConverter.ConvertToDocx(markdown, stream, options);
+        };
+
+        act.Should().NotThrow();
     }
 }

--- a/dotnet/tests/MarkMyWord.Tests/EmojiSegmenterTests.cs
+++ b/dotnet/tests/MarkMyWord.Tests/EmojiSegmenterTests.cs
@@ -1,0 +1,269 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using FluentAssertions;
+using MarkMyWord.OpenXml;
+
+namespace MarkMyWord.Tests;
+
+/// <summary>
+/// Tests for the EmojiSegmenter and EmojiRunHelper classes.
+/// Verifies correct detection, segmentation, and font application for emoji characters.
+/// </summary>
+public class EmojiSegmenterTests
+{
+    #region ContainsEmoji
+
+    [Theory]
+    [InlineData("Hello World", false)]
+    [InlineData("", false)]
+    [InlineData("Hello 😀 World", true)]
+    [InlineData("🔴", true)]
+    [InlineData("🔍 Discover", true)]
+    [InlineData("Tier: 🔴 Critical", true)]
+    [InlineData("Flag 🇺🇸 here", true)]
+    [InlineData("ABC 123 !@#", false)]
+    public void ContainsEmoji_DetectsCorrectly(string input, bool expected)
+    {
+        EmojiSegmenter.ContainsEmoji(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ContainsEmoji_NullInput_ReturnsFalse()
+    {
+        EmojiSegmenter.ContainsEmoji(null!).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Segment
+
+    [Fact]
+    public void Segment_PlainText_ReturnsSingleNonEmojiSegment()
+    {
+        var segments = EmojiSegmenter.Segment("Hello World");
+
+        segments.Should().HaveCount(1);
+        segments[0].Text.Should().Be("Hello World");
+        segments[0].IsEmoji.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Segment_OnlyEmoji_ReturnsSingleEmojiSegment()
+    {
+        var segments = EmojiSegmenter.Segment("🔴");
+
+        segments.Should().HaveCount(1);
+        segments[0].Text.Should().Be("🔴");
+        segments[0].IsEmoji.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Segment_EmojiInMiddle_ReturnsThreeSegments()
+    {
+        var segments = EmojiSegmenter.Segment("Tier: 🔴 Critical");
+
+        segments.Should().HaveCount(3);
+        segments[0].Text.Should().Be("Tier: ");
+        segments[0].IsEmoji.Should().BeFalse();
+        segments[1].Text.Should().Be("🔴");
+        segments[1].IsEmoji.Should().BeTrue();
+        segments[2].Text.Should().Be(" Critical");
+        segments[2].IsEmoji.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Segment_MultipleEmojis_MergesAdjacentEmoji()
+    {
+        var segments = EmojiSegmenter.Segment("🚀🎉💯");
+
+        segments.Should().HaveCount(1);
+        segments[0].IsEmoji.Should().BeTrue();
+        segments[0].Text.Should().Contain("🚀");
+        segments[0].Text.Should().Contain("🎉");
+        segments[0].Text.Should().Contain("💯");
+    }
+
+    [Fact]
+    public void Segment_EmptyString_ReturnsSingleEmptySegment()
+    {
+        var segments = EmojiSegmenter.Segment("");
+
+        segments.Should().HaveCount(1);
+        segments[0].Text.Should().BeEmpty();
+        segments[0].IsEmoji.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Segment_MixedContent_PreservesAllText()
+    {
+        var input = "🔍 Discover → 🤔 Understand → 🛠️ Build";
+        var segments = EmojiSegmenter.Segment(input);
+
+        // Verify all text is preserved when segments are concatenated
+        var reconstructed = string.Concat(segments.Select(s => s.Text));
+        reconstructed.Should().Be(input);
+    }
+
+    [Fact]
+    public void Segment_VariationSelector_TreatedAsEmoji()
+    {
+        // 🛠️ is U+1F6E0 + U+FE0F (variation selector 16)
+        var segments = EmojiSegmenter.Segment("Tools 🛠️ here");
+
+        segments.Should().HaveCountGreaterOrEqualTo(3);
+        segments.Should().Contain(s => s.IsEmoji && s.Text.Contains("🛠"));
+    }
+
+    #endregion
+
+    #region EmojiRunHelper
+
+    [Fact]
+    public void AppendText_PlainText_CreatesSingleRun()
+    {
+        var paragraph = new Paragraph();
+
+        EmojiRunHelper.AppendText(paragraph, "Hello World");
+
+        var runs = paragraph.Elements<Run>().ToList();
+        runs.Should().HaveCount(1);
+        runs[0].InnerText.Should().Be("Hello World");
+        // No emoji font should be applied
+        runs[0].RunProperties?.GetFirstChild<RunFonts>()?.Ascii?.Value
+            .Should().NotBe(EmojiSegmenter.EmojiFontName);
+    }
+
+    [Fact]
+    public void AppendText_EmojiText_AppliesEmojiFont()
+    {
+        var paragraph = new Paragraph();
+
+        EmojiRunHelper.AppendText(paragraph, "Tier: 🔴 Critical");
+
+        var runs = paragraph.Elements<Run>().ToList();
+        runs.Should().HaveCount(3);
+
+        // First run: "Tier: " — no emoji font
+        runs[0].InnerText.Should().Be("Tier: ");
+
+        // Second run: "🔴" — should have emoji font
+        runs[1].InnerText.Should().Be("🔴");
+        var emojiFont = runs[1].RunProperties?.GetFirstChild<RunFonts>();
+        emojiFont.Should().NotBeNull();
+        emojiFont!.Ascii!.Value.Should().Be(EmojiSegmenter.EmojiFontName);
+        emojiFont!.HighAnsi!.Value.Should().Be(EmojiSegmenter.EmojiFontName);
+
+        // Third run: " Critical" — no emoji font
+        runs[2].InnerText.Should().Be(" Critical");
+    }
+
+    [Fact]
+    public void AppendText_WithBaseRunProperties_PreservesFormattingOnBothSegments()
+    {
+        var paragraph = new Paragraph();
+        var boldProps = new RunProperties(new Bold());
+
+        EmojiRunHelper.AppendText(paragraph, "Bold 🔴 text", boldProps);
+
+        var runs = paragraph.Elements<Run>().ToList();
+        runs.Should().HaveCount(3);
+
+        // All runs should be bold
+        foreach (var run in runs)
+        {
+            run.RunProperties.Should().NotBeNull();
+            run.RunProperties!.GetFirstChild<Bold>().Should().NotBeNull();
+        }
+
+        // Emoji run should also have the emoji font
+        runs[1].RunProperties!.GetFirstChild<RunFonts>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AppendText_EmptyText_AddsNoRuns()
+    {
+        var paragraph = new Paragraph();
+
+        EmojiRunHelper.AppendText(paragraph, "");
+
+        paragraph.Elements<Run>().Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Integration — Emoji Font in Converted Documents
+
+    [Fact]
+    public void Convert_InlineEmoji_AppliesEmojiFont()
+    {
+        var markdown = "Tier: 🔴 Critical";
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(markdown);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var runs = body.Descendants<Run>().ToList();
+
+        // Find the run containing the red circle emoji
+        var emojiRun = runs.FirstOrDefault(r => r.InnerText.Contains("🔴"));
+        emojiRun.Should().NotBeNull("emoji should be present in the document");
+
+        var fonts = emojiRun!.RunProperties?.GetFirstChild<RunFonts>();
+        fonts.Should().NotBeNull("emoji run should have font properties");
+        fonts!.Ascii!.Value.Should().Be(EmojiSegmenter.EmojiFontName,
+            "emoji run should use Segoe UI Emoji for color rendering");
+    }
+
+    [Fact]
+    public void Convert_BoldWithEmoji_PreservesBoldAndAppliesEmojiFont()
+    {
+        var markdown = "**Tier: 🔴 Critical**";
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(markdown);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var runs = body.Descendants<Run>().ToList();
+
+        // Find the emoji run
+        var emojiRun = runs.FirstOrDefault(r => r.InnerText.Contains("🔴"));
+        emojiRun.Should().NotBeNull();
+
+        // Should have both bold and emoji font
+        var props = emojiRun!.RunProperties;
+        props.Should().NotBeNull();
+        props!.GetFirstChild<Bold>().Should().NotBeNull("emphasis should be preserved on emoji run");
+        props!.GetFirstChild<RunFonts>()?.Ascii?.Value.Should().Be(EmojiSegmenter.EmojiFontName);
+    }
+
+    [Fact]
+    public void Convert_MultipleEmojis_AllHaveEmojiFont()
+    {
+        var markdown = "🔍 Discover → 🤔 Understand → 📦 Publish";
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(markdown);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var body = doc.MainDocumentPart!.Document.Body!;
+        var runs = body.Descendants<Run>().ToList();
+
+        // All runs containing emoji should have the emoji font
+        var emojiRuns = runs.Where(r =>
+            EmojiSegmenter.ContainsEmoji(r.InnerText)).ToList();
+
+        emojiRuns.Should().NotBeEmpty("there should be emoji runs in the document");
+
+        foreach (var run in emojiRuns)
+        {
+            var fonts = run.RunProperties?.GetFirstChild<RunFonts>();
+            fonts.Should().NotBeNull($"emoji run '{run.InnerText}' should have font properties");
+            fonts!.Ascii!.Value.Should().Be(EmojiSegmenter.EmojiFontName);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Fixes #42

## Summary

Fixes two emoji rendering bugs:

### 1. Mermaid emoji support
MermaidSharp (Naiad) cannot parse astral-plane Unicode. This PR adds a pre-processing step that replaces emoji grapheme clusters with Private Use Area (U+E000+) placeholders before passing code to the parser, then restores them in the SVG output. This preserves emoji in rendered diagrams.

### 2. Color emoji in Word documents
Emoji characters like 🔴 were rendering as monochrome outlines because no emoji font was applied. This PR introduces:

- **\EmojiSegmenter\** — grapheme-cluster-aware emoji detection using \StringInfo.GetTextElementEnumerator\. Covers supplementary plane emoji, ZWJ sequences, variation selectors, regional indicators, and common BMP emoji.
- **\EmojiRunHelper\** — shared helper that splits text into emoji and non-emoji runs, applying \Segoe UI Emoji\ font (all four RunFonts slots: Ascii, HighAnsi, ComplexScript, EastAsia) to emoji segments.

All text-producing renderers now use \EmojiRunHelper\:
- \LiteralInlineRenderer\
- \EmphasisInlineRenderer\
- \LinkInlineRenderer\
- \TableRenderer\

### Tests
- 20+ new tests for EmojiSegmenter (detection, segmentation, edge cases)
- Integration tests verifying emoji font is applied in converted documents
- Mermaid emoji rendering tests (diagram renders, no fallback to code block)

All 295 tests pass.