### PR TITLE
Fix frontmatter rendering in output documents

### DIFF
--- a/dotnet/src/MarkMyWord/Configuration/FrontmatterExtractor.cs
+++ b/dotnet/src/MarkMyWord/Configuration/FrontmatterExtractor.cs
@@ -8,6 +8,14 @@ namespace MarkMyWord.Configuration;
 /// </summary>
 public static class FrontmatterExtractor
 {
+    private static readonly string[] DateFieldNames =
+    [
+        "date", "createdDate", "created_date", "createdTimestamp", "created_timestamp",
+        "created", "publishDate", "publish_date", "published", "publishedDate",
+        "published_date", "lastModified", "last_modified", "modifiedDate", "modified_date",
+        "updated", "updatedDate", "updated_date"
+    ];
+
     /// <summary>
     /// Extracts frontmatter data from a parsed Markdig document.
     /// Returns null if the document contains no YAML frontmatter block.
@@ -19,34 +27,78 @@ public static class FrontmatterExtractor
             return null;
 
         var fields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var authors = new List<string>();
         var lines = yamlBlock.Lines;
+        string? currentListKey = null;
 
         for (int i = 0; i < lines.Count; i++)
         {
             var line = lines.Lines[i].Slice.ToString();
             if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#'))
+            {
+                currentListKey = null;
                 continue;
+            }
+
+            // Check for YAML list item (e.g., "  - John Doe")
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("- ") && currentListKey != null)
+            {
+                var itemValue = StripQuotes(trimmed[2..].Trim());
+                if (!string.IsNullOrEmpty(itemValue))
+                    authors.Add(itemValue);
+                continue;
+            }
 
             var colonIndex = line.IndexOf(':');
             if (colonIndex <= 0)
+            {
+                currentListKey = null;
                 continue;
+            }
 
             var key = line[..colonIndex].Trim();
             var value = line[(colonIndex + 1)..].Trim();
+            value = StripQuotes(value);
 
-            // Strip matching surrounding quotes
-            if (value.Length >= 2 &&
-                ((value[0] == '"' && value[^1] == '"') ||
-                 (value[0] == '\'' && value[^1] == '\'')))
+            // If value is empty, this might be a list key (e.g., "authors:")
+            if (string.IsNullOrEmpty(value) &&
+                key.Equals("authors", StringComparison.OrdinalIgnoreCase))
             {
-                value = value[1..^1];
+                currentListKey = key;
+                continue;
             }
 
-            fields[key] = value;
+            currentListKey = null;
+
+            // Single "author" field
+            if (key.Equals("author", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(value))
+            {
+                authors.Add(value);
+            }
+
+            if (!string.IsNullOrEmpty(value))
+                fields[key] = value;
         }
 
-        return new FrontmatterData(fields);
+        return new FrontmatterData(fields, authors);
     }
+
+    private static string StripQuotes(string value)
+    {
+        if (value.Length >= 2 &&
+            ((value[0] == '"' && value[^1] == '"') ||
+             (value[0] == '\'' && value[^1] == '\'')))
+        {
+            return value[1..^1];
+        }
+        return value;
+    }
+
+    /// <summary>
+    /// Returns the list of recognized date field names (case-insensitive matching).
+    /// </summary>
+    internal static IReadOnlyList<string> GetDateFieldNames() => DateFieldNames;
 }
 
 /// <summary>
@@ -54,18 +106,42 @@ public static class FrontmatterExtractor
 /// </summary>
 public class FrontmatterData
 {
+    private static readonly string[] DateFieldNames = FrontmatterExtractor.GetDateFieldNames().ToArray();
+
     /// <summary>
     /// All frontmatter fields as key-value pairs (case-insensitive keys).
     /// </summary>
     public IReadOnlyDictionary<string, string> Fields { get; }
 
     /// <summary>
+    /// Authors extracted from the frontmatter ("author" for single, "authors" list for multiple).
+    /// </summary>
+    public IReadOnlyList<string> Authors { get; }
+
+    /// <summary>
     /// The document title from the frontmatter, if present.
     /// </summary>
     public string? Title => Fields.TryGetValue("title", out var title) ? title : null;
 
-    public FrontmatterData(Dictionary<string, string> fields)
+    /// <summary>
+    /// The document date, resolved from the first matching date field name.
+    /// </summary>
+    public string? Date
+    {
+        get
+        {
+            foreach (var name in DateFieldNames)
+            {
+                if (Fields.TryGetValue(name, out var value))
+                    return value;
+            }
+            return null;
+        }
+    }
+
+    public FrontmatterData(Dictionary<string, string> fields, List<string> authors)
     {
         Fields = fields;
+        Authors = authors;
     }
 }

--- a/dotnet/src/MarkMyWord/Configuration/FrontmatterExtractor.cs
+++ b/dotnet/src/MarkMyWord/Configuration/FrontmatterExtractor.cs
@@ -1,0 +1,71 @@
+using Markdig.Extensions.Yaml;
+using Markdig.Syntax;
+
+namespace MarkMyWord.Configuration;
+
+/// <summary>
+/// Extracts and parses YAML frontmatter from a Markdig document.
+/// </summary>
+public static class FrontmatterExtractor
+{
+    /// <summary>
+    /// Extracts frontmatter data from a parsed Markdig document.
+    /// Returns null if the document contains no YAML frontmatter block.
+    /// </summary>
+    public static FrontmatterData? Extract(MarkdownDocument document)
+    {
+        var yamlBlock = document.Descendants<YamlFrontMatterBlock>().FirstOrDefault();
+        if (yamlBlock == null)
+            return null;
+
+        var fields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var lines = yamlBlock.Lines;
+
+        for (int i = 0; i < lines.Count; i++)
+        {
+            var line = lines.Lines[i].Slice.ToString();
+            if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#'))
+                continue;
+
+            var colonIndex = line.IndexOf(':');
+            if (colonIndex <= 0)
+                continue;
+
+            var key = line[..colonIndex].Trim();
+            var value = line[(colonIndex + 1)..].Trim();
+
+            // Strip matching surrounding quotes
+            if (value.Length >= 2 &&
+                ((value[0] == '"' && value[^1] == '"') ||
+                 (value[0] == '\'' && value[^1] == '\'')))
+            {
+                value = value[1..^1];
+            }
+
+            fields[key] = value;
+        }
+
+        return new FrontmatterData(fields);
+    }
+}
+
+/// <summary>
+/// Represents parsed frontmatter data from a markdown document.
+/// </summary>
+public class FrontmatterData
+{
+    /// <summary>
+    /// All frontmatter fields as key-value pairs (case-insensitive keys).
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Fields { get; }
+
+    /// <summary>
+    /// The document title from the frontmatter, if present.
+    /// </summary>
+    public string? Title => Fields.TryGetValue("title", out var title) ? title : null;
+
+    public FrontmatterData(Dictionary<string, string> fields)
+    {
+        Fields = fields;
+    }
+}

--- a/dotnet/src/MarkMyWord/Converters/BlockRenderers/YamlFrontMatterRenderer.cs
+++ b/dotnet/src/MarkMyWord/Converters/BlockRenderers/YamlFrontMatterRenderer.cs
@@ -1,0 +1,15 @@
+using Markdig.Extensions.Yaml;
+
+namespace MarkMyWord.Converters.BlockRenderers;
+
+/// <summary>
+/// No-op renderer for YAML frontmatter blocks.
+/// Frontmatter is consumed for metadata extraction and should not appear in the document body.
+/// </summary>
+public class YamlFrontMatterRenderer : OpenXmlObjectRenderer<YamlFrontMatterBlock>
+{
+    protected override void Write(OpenXmlRenderer renderer, YamlFrontMatterBlock obj)
+    {
+        // Intentionally empty — frontmatter is not rendered as document content.
+    }
+}

--- a/dotnet/src/MarkMyWord/Converters/OpenXmlRenderer.cs
+++ b/dotnet/src/MarkMyWord/Converters/OpenXmlRenderer.cs
@@ -1,3 +1,4 @@
+using Markdig.Extensions.Yaml;
 using Markdig.Renderers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -37,6 +38,7 @@ public class OpenXmlRenderer : RendererBase, IDisposable
         }
 
         // Register block renderers
+        ObjectRenderers.Add(new YamlFrontMatterRenderer());
         ObjectRenderers.Add(new HeadingRenderer());
         ObjectRenderers.Add(new ParagraphRenderer());
         ObjectRenderers.Add(new CodeBlockRenderer());

--- a/dotnet/src/MarkMyWord/MarkdownConverter.cs
+++ b/dotnet/src/MarkMyWord/MarkdownConverter.cs
@@ -297,7 +297,7 @@ public static class MarkdownConverter
 
             var titleRun = new DocumentFormat.OpenXml.Wordprocessing.Run();
             titleRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text(frontmatter.Title)
-                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
             titleParagraph.AppendChild(titleRun);
         }
 
@@ -310,13 +310,13 @@ public static class MarkdownConverter
                 new DocumentFormat.OpenXml.Wordprocessing.Bold());
             var labelText = frontmatter.Authors.Count == 1 ? "Author: " : "Authors: ";
             labelRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text(labelText)
-                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
             authorParagraph.AppendChild(labelRun);
 
             var valueRun = new DocumentFormat.OpenXml.Wordprocessing.Run();
             valueRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text(
                 string.Join(", ", frontmatter.Authors))
-                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
             authorParagraph.AppendChild(valueRun);
         }
 
@@ -328,12 +328,12 @@ public static class MarkdownConverter
             labelRun.RunProperties = new DocumentFormat.OpenXml.Wordprocessing.RunProperties(
                 new DocumentFormat.OpenXml.Wordprocessing.Bold());
             labelRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text("Date: ")
-                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
             dateParagraph.AppendChild(labelRun);
 
             var valueRun = new DocumentFormat.OpenXml.Wordprocessing.Run();
             valueRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text(frontmatter.Date)
-                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
             dateParagraph.AppendChild(valueRun);
         }
     }

--- a/dotnet/src/MarkMyWord/MarkdownConverter.cs
+++ b/dotnet/src/MarkMyWord/MarkdownConverter.cs
@@ -166,7 +166,8 @@ public static class MarkdownConverter
             throw new ArgumentNullException(nameof(outputStream));
 
         // Parse markdown using Markdig with extensions
-        var pipelineBuilder = new MarkdownPipelineBuilder();
+        var pipelineBuilder = new MarkdownPipelineBuilder()
+            .UseYamlFrontMatter();
 
         // Enable extensions based on options
         if (options?.EnableTables ?? true)
@@ -177,8 +178,17 @@ public static class MarkdownConverter
         var pipeline = pipelineBuilder.Build();
         var document = Markdown.Parse(markdown, pipeline);
 
+        // Extract frontmatter and apply title to document properties
+        var frontmatter = FrontmatterExtractor.Extract(document);
+
         // Render to OpenXML
         using var renderer = new OpenXmlRenderer(outputStream, options);
+
+        if (frontmatter?.Title != null && string.IsNullOrEmpty(options?.DocumentTitle))
+        {
+            renderer.DocumentBuilder.SetDocumentProperties(title: frontmatter.Title);
+        }
+
         renderer.Render(document);
 
         // Inject Sidemark comments if provided

--- a/dotnet/src/MarkMyWord/MarkdownConverter.cs
+++ b/dotnet/src/MarkMyWord/MarkdownConverter.cs
@@ -189,6 +189,9 @@ public static class MarkdownConverter
             renderer.DocumentBuilder.SetDocumentProperties(title: frontmatter.Title);
         }
 
+        // Render frontmatter metadata as document header (title heading + author/date)
+        RenderFrontmatterHeader(renderer, frontmatter);
+
         renderer.Render(document);
 
         // Inject Sidemark comments if provided
@@ -274,5 +277,64 @@ public static class MarkdownConverter
     public static async Task ConvertToDocxAsync(Stream markdownStream, Stream outputStream, ConversionOptions? options = null, CancellationToken cancellationToken = default)
     {
         await Task.Run(() => ConvertToDocx(markdownStream, outputStream, options), cancellationToken);
+    }
+
+    /// <summary>
+    /// Renders frontmatter metadata as the document header:
+    /// title as an H1 heading, followed by author and date lines with bold labels.
+    /// </summary>
+    private static void RenderFrontmatterHeader(Converters.OpenXmlRenderer renderer, FrontmatterData? frontmatter)
+    {
+        if (frontmatter == null)
+            return;
+
+        // Render title as H1 heading
+        if (!string.IsNullOrEmpty(frontmatter.Title))
+        {
+            var headingProps = renderer.StyleManager.GetHeadingProperties(1);
+            var titleParagraph = renderer.DocumentBuilder.AddParagraph();
+            titleParagraph.ParagraphProperties = headingProps;
+
+            var titleRun = new DocumentFormat.OpenXml.Wordprocessing.Run();
+            titleRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text(frontmatter.Title)
+                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            titleParagraph.AppendChild(titleRun);
+        }
+
+        // Render authors with bold label
+        if (frontmatter.Authors.Count > 0)
+        {
+            var authorParagraph = renderer.DocumentBuilder.AddParagraph();
+            var labelRun = new DocumentFormat.OpenXml.Wordprocessing.Run();
+            labelRun.RunProperties = new DocumentFormat.OpenXml.Wordprocessing.RunProperties(
+                new DocumentFormat.OpenXml.Wordprocessing.Bold());
+            var labelText = frontmatter.Authors.Count == 1 ? "Author: " : "Authors: ";
+            labelRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text(labelText)
+                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            authorParagraph.AppendChild(labelRun);
+
+            var valueRun = new DocumentFormat.OpenXml.Wordprocessing.Run();
+            valueRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text(
+                string.Join(", ", frontmatter.Authors))
+                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            authorParagraph.AppendChild(valueRun);
+        }
+
+        // Render date with bold label
+        if (!string.IsNullOrEmpty(frontmatter.Date))
+        {
+            var dateParagraph = renderer.DocumentBuilder.AddParagraph();
+            var labelRun = new DocumentFormat.OpenXml.Wordprocessing.Run();
+            labelRun.RunProperties = new DocumentFormat.OpenXml.Wordprocessing.RunProperties(
+                new DocumentFormat.OpenXml.Wordprocessing.Bold());
+            labelRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text("Date: ")
+                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            dateParagraph.AppendChild(labelRun);
+
+            var valueRun = new DocumentFormat.OpenXml.Wordprocessing.Run();
+            valueRun.AppendChild(new DocumentFormat.OpenXml.Wordprocessing.Text(frontmatter.Date)
+                { Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve });
+            dateParagraph.AppendChild(valueRun);
+        }
     }
 }

--- a/dotnet/src/MarkMyWord/OfficeTalk/OfficeTalkCompiler.cs
+++ b/dotnet/src/MarkMyWord/OfficeTalk/OfficeTalkCompiler.cs
@@ -24,6 +24,7 @@ public class OfficeTalkCompiler
     private int _tableIndex;
     // Tracks the address of the last emitted element for INSERT AFTER chaining
     private string? _lastAddress;
+    private FrontmatterData? _frontmatter;
 
     public OfficeTalkCompiler(ConversionOptions? options = null)
     {
@@ -67,6 +68,7 @@ public class OfficeTalkCompiler
                 SidemarkFilePath = _options.SidemarkFilePath
             };
         }
+        _frontmatter = frontmatter;
 
         return Compile(document);
     }
@@ -98,8 +100,11 @@ public class OfficeTalkCompiler
         if (_options.DocumentTitle != null || _options.Author != null || _options.Subject != null)
             _output.AppendLine();
 
-        // Walk AST blocks (skip frontmatter blocks)
+        // Emit frontmatter metadata as document header (title heading + author/date)
         bool isFirst = true;
+        isFirst = EmitFrontmatterHeader(isFirst);
+
+        // Walk AST blocks (skip frontmatter blocks)
         foreach (var block in document)
         {
             if (block is YamlFrontMatterBlock)
@@ -110,6 +115,100 @@ public class OfficeTalkCompiler
         }
 
         return _output.ToString();
+    }
+
+    /// <summary>
+    /// Emits frontmatter metadata as a title heading and author/date paragraphs.
+    /// Returns the updated isFirst flag.
+    /// </summary>
+    private bool EmitFrontmatterHeader(bool isFirst)
+    {
+        if (_frontmatter == null)
+            return isFirst;
+
+        // Emit title as Heading1
+        if (!string.IsNullOrEmpty(_frontmatter.Title))
+        {
+            if (isFirst)
+            {
+                _output.AppendLine($"AT body/paragraph[{_paragraphIndex}]");
+                _output.AppendLine($"SET \"{Escape(_frontmatter.Title)}\"");
+                _output.AppendLine("STYLE \"Heading1\"");
+                _output.AppendLine();
+                _paragraphIndex--;
+                _headingIndex++;
+                _lastAddress = $"body/heading[{_headingIndex}]";
+            }
+            else
+            {
+                _output.AppendLine($"AT {_lastAddress}");
+                _output.AppendLine("INSERT AFTER \"\"");
+                _output.AppendLine();
+                _paragraphIndex++;
+
+                _output.AppendLine($"AT body/paragraph[{_paragraphIndex}]");
+                _output.AppendLine($"SET \"{Escape(_frontmatter.Title)}\"");
+                _output.AppendLine("STYLE \"Heading1\"");
+                _output.AppendLine();
+                _paragraphIndex--;
+                _headingIndex++;
+                _lastAddress = $"body/heading[{_headingIndex}]";
+            }
+            isFirst = false;
+        }
+
+        // Emit authors
+        if (_frontmatter.Authors.Count > 0)
+        {
+            var label = _frontmatter.Authors.Count == 1 ? "Author: " : "Authors: ";
+            var value = string.Join(", ", _frontmatter.Authors);
+
+            if (isFirst)
+            {
+                _output.AppendLine($"AT body/paragraph[{_paragraphIndex}]");
+            }
+            else
+            {
+                _output.AppendLine($"AT {_lastAddress}");
+                _output.AppendLine("INSERT AFTER \"\"");
+                _output.AppendLine();
+                _paragraphIndex++;
+                _output.AppendLine($"AT body/paragraph[{_paragraphIndex}]");
+            }
+
+            _output.AppendLine("SET RUNS");
+            _output.AppendLine($"  RUN \"{Escape(label)}\" bold=true");
+            _output.AppendLine($"  RUN \"{Escape(value)}\"");
+            _output.AppendLine();
+            _lastAddress = $"body/paragraph[{_paragraphIndex}]";
+            isFirst = false;
+        }
+
+        // Emit date
+        if (!string.IsNullOrEmpty(_frontmatter.Date))
+        {
+            if (isFirst)
+            {
+                _output.AppendLine($"AT body/paragraph[{_paragraphIndex}]");
+            }
+            else
+            {
+                _output.AppendLine($"AT {_lastAddress}");
+                _output.AppendLine("INSERT AFTER \"\"");
+                _output.AppendLine();
+                _paragraphIndex++;
+                _output.AppendLine($"AT body/paragraph[{_paragraphIndex}]");
+            }
+
+            _output.AppendLine("SET RUNS");
+            _output.AppendLine($"  RUN \"Date: \" bold=true");
+            _output.AppendLine($"  RUN \"{Escape(_frontmatter.Date)}\"");
+            _output.AppendLine();
+            _lastAddress = $"body/paragraph[{_paragraphIndex}]";
+            isFirst = false;
+        }
+
+        return isFirst;
     }
 
     private void CompileBlock(Block block, bool isFirst)

--- a/dotnet/src/MarkMyWord/OfficeTalk/OfficeTalkCompiler.cs
+++ b/dotnet/src/MarkMyWord/OfficeTalk/OfficeTalkCompiler.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Markdig;
 using Markdig.Extensions.Tables;
+using Markdig.Extensions.Yaml;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using MarkMyWord.Configuration;
@@ -14,7 +15,7 @@ namespace MarkMyWord.OfficeTalk;
 /// </summary>
 public class OfficeTalkCompiler
 {
-    private readonly ConversionOptions _options;
+    private ConversionOptions _options;
     private readonly StyleConfiguration _styles;
     private readonly SyntaxHighlighterFactory _highlighter = new();
     private readonly StringBuilder _output = new();
@@ -36,10 +37,37 @@ public class OfficeTalkCompiler
     public string Compile(string markdown)
     {
         var pipeline = new MarkdownPipelineBuilder()
+            .UseYamlFrontMatter()
             .UseAdvancedExtensions()
             .Build();
 
         var document = Markdown.Parse(markdown, pipeline);
+
+        // Extract frontmatter title and apply it to document properties
+        var frontmatter = FrontmatterExtractor.Extract(document);
+        if (frontmatter?.Title != null && string.IsNullOrEmpty(_options.DocumentTitle))
+        {
+            _options = new ConversionOptions
+            {
+                DocumentTitle = frontmatter.Title,
+                Author = _options.Author,
+                Subject = _options.Subject,
+                Styles = _options.Styles,
+                EnableAdvancedExtensions = _options.EnableAdvancedExtensions,
+                EnableTables = _options.EnableTables,
+                EnableTaskLists = _options.EnableTaskLists,
+                EnableSyntaxHighlighting = _options.EnableSyntaxHighlighting,
+                ImageStrategy = _options.ImageStrategy,
+                MaxImageWidthInches = _options.MaxImageWidthInches,
+                EnableMermaidDiagrams = _options.EnableMermaidDiagrams,
+                MaxDiagramWidthInches = _options.MaxDiagramWidthInches,
+                MaxDiagramHeightInches = _options.MaxDiagramHeightInches,
+                Theme = _options.Theme,
+                SidemarkDocument = _options.SidemarkDocument,
+                SidemarkFilePath = _options.SidemarkFilePath
+            };
+        }
+
         return Compile(document);
     }
 
@@ -70,10 +98,13 @@ public class OfficeTalkCompiler
         if (_options.DocumentTitle != null || _options.Author != null || _options.Subject != null)
             _output.AppendLine();
 
-        // Walk AST blocks
+        // Walk AST blocks (skip frontmatter blocks)
         bool isFirst = true;
         foreach (var block in document)
         {
+            if (block is YamlFrontMatterBlock)
+                continue;
+
             CompileBlock(block, isFirst);
             isFirst = false;
         }

--- a/dotnet/tests/MarkMyWord.Tests/FrontmatterTests.cs
+++ b/dotnet/tests/MarkMyWord.Tests/FrontmatterTests.cs
@@ -20,6 +20,21 @@ public class FrontmatterTests
         Body text content.
         """;
 
+    private const string MarkdownWithMultipleAuthors = """
+        ---
+        title: Team Document
+        authors:
+          - Alice Smith
+          - Bob Jones
+          - Carol White
+        date: 2026-05-22
+        ---
+
+        ## Introduction
+
+        Some content.
+        """;
+
     private const string MarkdownWithQuotedTitle = """
         ---
         title: "Quoted Document Title"
@@ -36,8 +51,26 @@ public class FrontmatterTests
         Body text content.
         """;
 
+    private const string MarkdownWithCreatedDate = """
+        ---
+        title: Date Variants
+        createdDate: 2026-01-15
+        ---
+
+        Content here.
+        """;
+
+    private const string MarkdownWithPublishDate = """
+        ---
+        title: Published Doc
+        publishDate: 2026-03-01
+        ---
+
+        Content here.
+        """;
+
     [Fact]
-    public void Frontmatter_ShouldNotAppearAsVisibleText()
+    public void Frontmatter_ShouldNotRenderRawYamlAsText()
     {
         var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithFrontmatter);
 
@@ -46,11 +79,28 @@ public class FrontmatterTests
 
         var bodyText = doc.MainDocumentPart!.Document.Body!.InnerText;
 
-        bodyText.Should().NotContain("Hidden Metadata Title");
-        bodyText.Should().NotContain("Jane Doe");
-        bodyText.Should().NotContain("2026-05-22");
+        // Raw frontmatter fields should not appear as-is
+        bodyText.Should().NotContain("---");
+        bodyText.Should().NotContain("title:");
+        bodyText.Should().NotContain("author:");
         bodyText.Should().Contain("Visible Heading");
         bodyText.Should().Contain("Body text content.");
+    }
+
+    [Fact]
+    public void FrontmatterTitle_ShouldRenderAsH1Heading()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithFrontmatter);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var paragraphs = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().ToList();
+        var titleParagraph = paragraphs.First();
+
+        titleParagraph.InnerText.Should().Be("Hidden Metadata Title");
+        titleParagraph.ParagraphProperties?.ParagraphStyleId?.Val?.Value
+            .Should().Be("Heading1");
     }
 
     [Fact]
@@ -62,6 +112,87 @@ public class FrontmatterTests
         using var doc = WordprocessingDocument.Open(ms, false);
 
         doc.PackageProperties.Title.Should().Be("Hidden Metadata Title");
+    }
+
+    [Fact]
+    public void FrontmatterAuthor_ShouldRenderWithBoldLabel()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithFrontmatter);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var paragraphs = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().ToList();
+        var authorParagraph = paragraphs.First(p => p.InnerText.Contains("Author:"));
+
+        // Label "Author: " should be bold
+        var runs = authorParagraph.Elements<Run>().ToList();
+        runs.Should().HaveCountGreaterThanOrEqualTo(2);
+        runs[0].RunProperties?.Bold.Should().NotBeNull();
+        runs[0].InnerText.Should().Be("Author: ");
+
+        // Value should not be bold
+        runs[1].InnerText.Should().Be("Jane Doe");
+    }
+
+    [Fact]
+    public void FrontmatterMultipleAuthors_ShouldRenderAsList()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithMultipleAuthors);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var paragraphs = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().ToList();
+        var authorParagraph = paragraphs.First(p => p.InnerText.Contains("Authors:"));
+
+        var runs = authorParagraph.Elements<Run>().ToList();
+        runs[0].RunProperties?.Bold.Should().NotBeNull();
+        runs[0].InnerText.Should().Be("Authors: ");
+        runs[1].InnerText.Should().Be("Alice Smith, Bob Jones, Carol White");
+    }
+
+    [Fact]
+    public void FrontmatterDate_ShouldRenderWithBoldLabel()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithFrontmatter);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var paragraphs = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().ToList();
+        var dateParagraph = paragraphs.First(p => p.InnerText.Contains("Date:"));
+
+        var runs = dateParagraph.Elements<Run>().ToList();
+        runs[0].RunProperties?.Bold.Should().NotBeNull();
+        runs[0].InnerText.Should().Be("Date: ");
+        runs[1].InnerText.Should().Be("2026-05-22");
+    }
+
+    [Fact]
+    public void FrontmatterDate_ShouldSupportCreatedDateField()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithCreatedDate);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var bodyText = doc.MainDocumentPart!.Document.Body!.InnerText;
+        bodyText.Should().Contain("Date: ");
+        bodyText.Should().Contain("2026-01-15");
+    }
+
+    [Fact]
+    public void FrontmatterDate_ShouldSupportPublishDateField()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithPublishDate);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var bodyText = doc.MainDocumentPart!.Document.Body!.InnerText;
+        bodyText.Should().Contain("Date: ");
+        bodyText.Should().Contain("2026-03-01");
     }
 
     [Fact]
@@ -98,6 +229,8 @@ public class FrontmatterTests
         var bodyText = doc.MainDocumentPart!.Document.Body!.InnerText;
         bodyText.Should().Contain("Visible Heading");
         bodyText.Should().Contain("Body text content.");
+        bodyText.Should().NotContain("Author:");
+        bodyText.Should().NotContain("Date:");
     }
 
     [Fact]
@@ -106,28 +239,42 @@ public class FrontmatterTests
         var otk = MarkdownConverter.CompileToOtk(MarkdownWithFrontmatter);
 
         otk.Should().Contain("PROPERTY title=\"Hidden Metadata Title\"");
-        otk.Should().NotContain("Jane Doe");
-        otk.Should().NotContain("2026-05-22");
     }
 
     [Fact]
-    public void OtkPipeline_FrontmatterShouldNotAppearAsContent()
+    public void OtkPipeline_FrontmatterTitle_ShouldEmitHeading1()
     {
         var otk = MarkdownConverter.CompileToOtk(MarkdownWithFrontmatter);
 
-        // The frontmatter text should not appear in any SET or INSERT operations
-        // Only the title should appear as a PROPERTY
-        var lines = otk.Split('\n');
-        var contentLines = lines.Where(l =>
-            l.TrimStart().StartsWith("SET ") ||
-            l.TrimStart().StartsWith("INSERT "));
+        otk.Should().Contain("STYLE \"Heading1\"");
+        otk.Should().Contain("SET \"Hidden Metadata Title\"");
+    }
 
-        foreach (var line in contentLines)
-        {
-            line.Should().NotContain("Hidden Metadata Title");
-            line.Should().NotContain("Jane Doe");
-            line.Should().NotContain("2026-05-22");
-        }
+    [Fact]
+    public void OtkPipeline_FrontmatterAuthor_ShouldEmitBoldRun()
+    {
+        var otk = MarkdownConverter.CompileToOtk(MarkdownWithFrontmatter);
+
+        otk.Should().Contain("RUN \"Author: \" bold=true");
+        otk.Should().Contain("RUN \"Jane Doe\"");
+    }
+
+    [Fact]
+    public void OtkPipeline_FrontmatterDate_ShouldEmitBoldRun()
+    {
+        var otk = MarkdownConverter.CompileToOtk(MarkdownWithFrontmatter);
+
+        otk.Should().Contain("RUN \"Date: \" bold=true");
+        otk.Should().Contain("RUN \"2026-05-22\"");
+    }
+
+    [Fact]
+    public void OtkPipeline_MultipleAuthors_ShouldEmitAuthorsLabel()
+    {
+        var otk = MarkdownConverter.CompileToOtk(MarkdownWithMultipleAuthors);
+
+        otk.Should().Contain("RUN \"Authors: \" bold=true");
+        otk.Should().Contain("RUN \"Alice Smith, Bob Jones, Carol White\"");
     }
 
     [Fact]
@@ -143,7 +290,7 @@ public class FrontmatterTests
     [Fact]
     public void FrontmatterExtractor_ShouldReturnNullForNoFrontmatter()
     {
-        var pipeline = new Markdig.MarkdownPipelineBuilder()
+        var pipeline = new MarkdownPipelineBuilder()
             .UseYamlFrontMatter()
             .Build();
         var document = Markdig.Markdown.Parse("# Just a heading\n\nSome text.", pipeline);
@@ -156,7 +303,7 @@ public class FrontmatterTests
     [Fact]
     public void FrontmatterExtractor_ShouldParseFlatYaml()
     {
-        var pipeline = new Markdig.MarkdownPipelineBuilder()
+        var pipeline = new MarkdownPipelineBuilder()
             .UseYamlFrontMatter()
             .Build();
         var document = Markdig.Markdown.Parse("---\ntitle: My Title\nauthor: John\n---\n\nContent", pipeline);
@@ -165,14 +312,30 @@ public class FrontmatterTests
 
         result.Should().NotBeNull();
         result!.Title.Should().Be("My Title");
-        result.Fields.Should().ContainKey("author");
-        result.Fields["author"].Should().Be("John");
+        result.Authors.Should().ContainSingle().Which.Should().Be("John");
+    }
+
+    [Fact]
+    public void FrontmatterExtractor_ShouldParseAuthorsArray()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseYamlFrontMatter()
+            .Build();
+        var md = "---\ntitle: Doc\nauthors:\n  - Alice\n  - Bob\n---\n\nContent";
+        var document = Markdig.Markdown.Parse(md, pipeline);
+
+        var result = FrontmatterExtractor.Extract(document);
+
+        result.Should().NotBeNull();
+        result!.Authors.Should().HaveCount(2);
+        result.Authors[0].Should().Be("Alice");
+        result.Authors[1].Should().Be("Bob");
     }
 
     [Fact]
     public void FrontmatterExtractor_ShouldStripQuotesFromValues()
     {
-        var pipeline = new Markdig.MarkdownPipelineBuilder()
+        var pipeline = new MarkdownPipelineBuilder()
             .UseYamlFrontMatter()
             .Build();
         var document = Markdig.Markdown.Parse("---\ntitle: \"Quoted Title\"\nother: 'Single Quoted'\n---\n\nContent", pipeline);
@@ -182,5 +345,43 @@ public class FrontmatterTests
         result.Should().NotBeNull();
         result!.Title.Should().Be("Quoted Title");
         result.Fields["other"].Should().Be("Single Quoted");
+    }
+
+    [Fact]
+    public void FrontmatterExtractor_ShouldResolveDateFromVariousFieldNames()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseYamlFrontMatter()
+            .Build();
+
+        // "createdTimestamp" should be recognized
+        var document = Markdig.Markdown.Parse("---\ncreatedTimestamp: 2025-12-01\n---\n\nContent", pipeline);
+        var result = FrontmatterExtractor.Extract(document);
+
+        result.Should().NotBeNull();
+        result!.Date.Should().Be("2025-12-01");
+    }
+
+    [Fact]
+    public void TitleHeaderOrder_ShouldBeTitleThenAuthorThenDate()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithFrontmatter);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var paragraphs = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().ToList();
+
+        // First paragraph: title heading
+        paragraphs[0].InnerText.Should().Be("Hidden Metadata Title");
+        paragraphs[0].ParagraphProperties?.ParagraphStyleId?.Val?.Value.Should().Be("Heading1");
+
+        // Second paragraph: author
+        paragraphs[1].InnerText.Should().Contain("Author:");
+        paragraphs[1].InnerText.Should().Contain("Jane Doe");
+
+        // Third paragraph: date
+        paragraphs[2].InnerText.Should().Contain("Date:");
+        paragraphs[2].InnerText.Should().Contain("2026-05-22");
     }
 }

--- a/dotnet/tests/MarkMyWord.Tests/FrontmatterTests.cs
+++ b/dotnet/tests/MarkMyWord.Tests/FrontmatterTests.cs
@@ -1,0 +1,186 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using FluentAssertions;
+using Markdig;
+using MarkMyWord.Configuration;
+
+namespace MarkMyWord.Tests;
+
+public class FrontmatterTests
+{
+    private const string MarkdownWithFrontmatter = """
+        ---
+        title: Hidden Metadata Title
+        author: Jane Doe
+        date: 2026-05-22
+        ---
+
+        # Visible Heading
+
+        Body text content.
+        """;
+
+    private const string MarkdownWithQuotedTitle = """
+        ---
+        title: "Quoted Document Title"
+        ---
+
+        # Visible Heading
+
+        Body text content.
+        """;
+
+    private const string MarkdownWithoutFrontmatter = """
+        # Visible Heading
+
+        Body text content.
+        """;
+
+    [Fact]
+    public void Frontmatter_ShouldNotAppearAsVisibleText()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithFrontmatter);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var bodyText = doc.MainDocumentPart!.Document.Body!.InnerText;
+
+        bodyText.Should().NotContain("Hidden Metadata Title");
+        bodyText.Should().NotContain("Jane Doe");
+        bodyText.Should().NotContain("2026-05-22");
+        bodyText.Should().Contain("Visible Heading");
+        bodyText.Should().Contain("Body text content.");
+    }
+
+    [Fact]
+    public void FrontmatterTitle_ShouldBeUsedAsDocumentTitle()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithFrontmatter);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        doc.PackageProperties.Title.Should().Be("Hidden Metadata Title");
+    }
+
+    [Fact]
+    public void FrontmatterQuotedTitle_ShouldBeStripped()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithQuotedTitle);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        doc.PackageProperties.Title.Should().Be("Quoted Document Title");
+    }
+
+    [Fact]
+    public void ExplicitDocumentTitle_ShouldTakePrecedenceOverFrontmatter()
+    {
+        var options = new ConversionOptions { DocumentTitle = "Explicit Title" };
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithFrontmatter, options);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        doc.PackageProperties.Title.Should().Be("Explicit Title");
+    }
+
+    [Fact]
+    public void WithoutFrontmatter_ShouldStillWorkNormally()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(MarkdownWithoutFrontmatter);
+
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+
+        var bodyText = doc.MainDocumentPart!.Document.Body!.InnerText;
+        bodyText.Should().Contain("Visible Heading");
+        bodyText.Should().Contain("Body text content.");
+    }
+
+    [Fact]
+    public void OtkPipeline_FrontmatterTitle_ShouldBeInDocumentProperties()
+    {
+        var otk = MarkdownConverter.CompileToOtk(MarkdownWithFrontmatter);
+
+        otk.Should().Contain("PROPERTY title=\"Hidden Metadata Title\"");
+        otk.Should().NotContain("Jane Doe");
+        otk.Should().NotContain("2026-05-22");
+    }
+
+    [Fact]
+    public void OtkPipeline_FrontmatterShouldNotAppearAsContent()
+    {
+        var otk = MarkdownConverter.CompileToOtk(MarkdownWithFrontmatter);
+
+        // The frontmatter text should not appear in any SET or INSERT operations
+        // Only the title should appear as a PROPERTY
+        var lines = otk.Split('\n');
+        var contentLines = lines.Where(l =>
+            l.TrimStart().StartsWith("SET ") ||
+            l.TrimStart().StartsWith("INSERT "));
+
+        foreach (var line in contentLines)
+        {
+            line.Should().NotContain("Hidden Metadata Title");
+            line.Should().NotContain("Jane Doe");
+            line.Should().NotContain("2026-05-22");
+        }
+    }
+
+    [Fact]
+    public void OtkPipeline_WithoutFrontmatter_ShouldStillWorkNormally()
+    {
+        var otk = MarkdownConverter.CompileToOtk(MarkdownWithoutFrontmatter);
+
+        otk.Should().Contain("Visible Heading");
+        otk.Should().Contain("Body text content.");
+        otk.Should().NotContain("PROPERTY title=");
+    }
+
+    [Fact]
+    public void FrontmatterExtractor_ShouldReturnNullForNoFrontmatter()
+    {
+        var pipeline = new Markdig.MarkdownPipelineBuilder()
+            .UseYamlFrontMatter()
+            .Build();
+        var document = Markdig.Markdown.Parse("# Just a heading\n\nSome text.", pipeline);
+
+        var result = FrontmatterExtractor.Extract(document);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void FrontmatterExtractor_ShouldParseFlatYaml()
+    {
+        var pipeline = new Markdig.MarkdownPipelineBuilder()
+            .UseYamlFrontMatter()
+            .Build();
+        var document = Markdig.Markdown.Parse("---\ntitle: My Title\nauthor: John\n---\n\nContent", pipeline);
+
+        var result = FrontmatterExtractor.Extract(document);
+
+        result.Should().NotBeNull();
+        result!.Title.Should().Be("My Title");
+        result.Fields.Should().ContainKey("author");
+        result.Fields["author"].Should().Be("John");
+    }
+
+    [Fact]
+    public void FrontmatterExtractor_ShouldStripQuotesFromValues()
+    {
+        var pipeline = new Markdig.MarkdownPipelineBuilder()
+            .UseYamlFrontMatter()
+            .Build();
+        var document = Markdig.Markdown.Parse("---\ntitle: \"Quoted Title\"\nother: 'Single Quoted'\n---\n\nContent", pipeline);
+
+        var result = FrontmatterExtractor.Extract(document);
+
+        result.Should().NotBeNull();
+        result!.Title.Should().Be("Quoted Title");
+        result.Fields["other"].Should().Be("Single Quoted");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #44 — YAML frontmatter was rendered as visible text in Word output.

### Changes

**Frontmatter is now parsed and consumed as metadata instead of rendered as content:**

- **Title** → Rendered as an H1 heading at the top of the document and set as document title metadata
- **Author/Authors** → Rendered as \**Author:** Name\ or \**Authors:** Name1, Name2\
  - Supports \uthor\ (single string) and \uthors\ (YAML array)
- **Date** → Rendered as \**Date:** value\ with support for multiple field names: \date\, \createdDate\, \created_date\, \createdTimestamp\, \publishDate\, \published\, \lastModified\, and more
- All other frontmatter fields are silently ignored
- Explicit \ConversionOptions.DocumentTitle\ takes precedence over frontmatter

### Files Changed

| File | Description |
|------|-------------|
| \FrontmatterExtractor.cs\ | New — parses YAML frontmatter, extracts title/authors/date |
| \YamlFrontMatterRenderer.cs\ | New — no-op renderer to skip frontmatter blocks |
| \MarkdownConverter.cs\ | Enable YAML frontmatter extension, render metadata header |
| \OfficeTalkCompiler.cs\ | Enable YAML frontmatter extension, emit metadata in OTK |
| \OpenXmlRenderer.cs\ | Register frontmatter renderer |
| \FrontmatterTests.cs\ | 23 new tests covering both pipelines |

### Testing

All 318 tests pass (23 new + 295 existing).