### PR TITLE
Tests + spec note: preserve hyperlinks inside table cells (closes #46)

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -18,6 +18,7 @@ MarkMyWord provides bidirectional conversion between Markdown and Word:
 - Thematic breaks (`---`, `***`, `___`)
 - **Lists** (ordered, unordered, nested with proper indentation)
 - **Tables** (with headers, borders, and shading)
+  - All inline elements supported in prose (hyperlinks, inline code, emphasis/strong, line breaks, images) are also rendered inside table cells. Images currently render as `[Image: alt]` placeholders.
 
 ✅ **Inline Elements**
 - Bold (`**text**` or `__text__`)
@@ -731,6 +732,7 @@ MIT License - See LICENSE file for details
 - **Lists** (ordered, unordered, nested with proper numbering)
 - **Images** (local files and URLs with fallback support)
 - **Tables** (with headers, borders, and shading)
+  - All inline elements supported in prose (hyperlinks, inline code, emphasis/strong, line breaks, images) are also rendered inside table cells. Images currently render as `[Image: alt]` placeholders.
 - Command-line interface with full options
 - Spell/grammar check suppression for code
 

--- a/dotnet/tests/MarkMyWord.Tests/BlockElements/TableHyperlinkTests.cs
+++ b/dotnet/tests/MarkMyWord.Tests/BlockElements/TableHyperlinkTests.cs
@@ -1,0 +1,71 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using FluentAssertions;
+using Xunit;
+
+namespace MarkMyWord.Tests.BlockElements;
+
+public class TableHyperlinkTests
+{
+    private const string ReproMarkdown = @"# Repro
+
+A link in prose: [foo](https://example.com/foo)
+
+| col1 | col2 |
+|---|---|
+| plain | [bar](https://example.com/bar) |
+| [baz](https://example.com/baz) | text with [inline link](https://example.com/inline) inside |
+";
+
+    [Fact]
+    public void TableCellsWithLinks_ShouldPreserveAllHyperlinks()
+    {
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(ReproMarkdown);
+
+        using var stream = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(stream, false);
+        var mainPart = doc.MainDocumentPart!;
+
+        var expectedUrls = new[]
+        {
+            "https://example.com/foo",
+            "https://example.com/bar",
+            "https://example.com/baz",
+            "https://example.com/inline",
+        };
+
+        var relUrls = mainPart.HyperlinkRelationships.Select(r => r.Uri.ToString()).ToList();
+        foreach (var url in expectedUrls)
+        {
+            relUrls.Should().Contain(url, $"hyperlink relationship for {url} should exist");
+        }
+
+        var hyperlinks = mainPart.Document.Body!.Descendants<Hyperlink>().ToList();
+        hyperlinks.Should().HaveCount(4, "all four markdown links (prose + 3 in-table) should be preserved as Word hyperlinks");
+
+        foreach (var url in expectedUrls)
+        {
+            var rel = mainPart.HyperlinkRelationships.FirstOrDefault(r => r.Uri.ToString() == url);
+            rel.Should().NotBeNull($"relationship for {url} should be present");
+            hyperlinks.Should().Contain(h => h.Id == rel!.Id, $"a Hyperlink element should reference the relationship for {url}");
+        }
+    }
+
+    [Fact]
+    public void TableCellLink_ShouldUseHyperlinkRelationshipFromMainDocumentPart()
+    {
+        var markdown = @"| col |
+|---|
+| [only](https://example.com/only) |
+";
+        var docxBytes = MarkdownConverter.ConvertToDocxBytes(markdown);
+
+        using var stream = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(stream, false);
+        var mainPart = doc.MainDocumentPart!;
+
+        var hyperlink = mainPart.Document.Body!.Descendants<Hyperlink>().Single();
+        var rel = mainPart.HyperlinkRelationships.Single(r => r.Id == hyperlink.Id);
+        rel.Uri.ToString().Should().Be("https://example.com/only");
+    }
+}


### PR DESCRIPTION
Closes #46.

## Summary

The `TableRenderer` hyperlink branch added in #43 already preserves `[text](url)` markdown links inside GFM table cells when converting markdown → `.docx` via the default `MarkdownConverter.ConvertToDocxBytes` pipeline. However:

- there was no regression test locking that behaviour in, and
- the `dotnet/README.md` did not document the requirement that inline elements supported in prose are also supported inside table cells.

The published `SpecWorks.MarkMyWord.CLI` 0.9.0 predates #43 and still exhibits the bug from #46.

## Changes

- **Tests** (new file `dotnet/tests/MarkMyWord.Tests/BlockElements/TableHyperlinkTests.cs`)
  - `TableCellsWithLinks_ShouldPreserveAllHyperlinks` — converts the minimal repro from #46 and asserts the resulting `WordprocessingDocument` has 4 hyperlink relationships on the `MainDocumentPart` matching the expected URLs, plus 4 `Hyperlink` elements in the body each referencing the corresponding relationship id.
  - `TableCellLink_ShouldUseHyperlinkRelationshipFromMainDocumentPart` — converts a single-cell table with one link and asserts the `Hyperlink.Id` matches a relationship on the `MainDocumentPart` pointing at the correct URI.
- **Spec / README**: documents under the `Tables` feature in `dotnet/README.md` (in both the "Currently Supported" and "Status" sections) that all inline elements supported in prose (hyperlinks, inline code, emphasis/strong, line breaks, images) are also rendered inside table cells, and notes that images currently render as `[Image: alt]` placeholders.

## Scope notes

- Tests are scoped to the default rendering path (`MarkdownConverter.ConvertToDocxBytes` → `TableRenderer`). The opt-in OfficeTalk pipeline (`--via-otk`) is not in scope.
- No source code changes — the renderer fix already landed in #43.

## Local verification

- [x] `dotnet build dotnet/MarkMyWord.sln` — succeeds
- [x] `dotnet test dotnet/MarkMyWord.sln` — **297** passed, 0 failed (295 pre-existing + 2 new)
- [x] `dotnet format dotnet/ --verify-no-changes --verbosity diagnostic` — clean (formatted 0 of 70 files)
